### PR TITLE
Show month and year in post listings

### DIFF
--- a/components/PostListTable.tsx
+++ b/components/PostListTable.tsx
@@ -26,9 +26,9 @@ export default function PostListTable({
         </thead>
         <tbody>
           {posts.map((post) => {
-            const year = new Date(post.date).getFullYear();
             const url = `/${locale === "en" ? "" : "fr/"}blog/${post.slug}`;
             const formatted = new Date(post.date).toLocaleDateString(locale, {
+              month: "short",
               year: "numeric",
             });
 


### PR DESCRIPTION
## Summary
- display month and year for each post in `PostListTable`

## Testing
- `npm run build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686ccbcb21c88325bbfb3bab979c2537